### PR TITLE
Update index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,7 +38,7 @@ declare type map<
 declare namespace ByteNet {
   export function definePacket<T extends ByteNetType<any>>(packetProps: {
     value: T;
-    reliabilityType: "reliable" | "unreliable";
+    reliabilityType?: "reliable" | "unreliable";
   }): packet<T>;
 
   export function defineNamespace<

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,7 +22,7 @@ type ByteNetType<T> = {
   value: T;
 };
 
-declare type array<T extends ByteNetType<any>> = ByteNetType<T[]>;
+declare type array<T extends ByteNetType<any>> = ByteNetType<T["value"][]>;
 declare type struct<T extends { [index: string]: ByteNetType<any> }> =
   ByteNetType<{
     [valueName in keyof T]: T[valueName]["value"];


### PR DESCRIPTION
* Use the inner `value` type of the ByteNetType given to an array. Fixes https://github.com/ffrostflame/ByteNet/issues/11.
* Make reliabilityType optional.