### PR TITLE
Sets achievable false for instances created in ReplicatedStorage

### DIFF
--- a/src/process/server.luau
+++ b/src/process/server.luau
@@ -88,11 +88,13 @@ end
 function serverProcess.start()
 	local reliableRemote = Instance.new("RemoteEvent")
 	reliableRemote.Name = "ByteNetReliable"
+	reliableRemote.Archivable = false
 	reliableRemote.OnServerEvent:Connect(onServerEvent)
 	reliableRemote.Parent = ReplicatedStorage
 
 	local unreliableRemote = Instance.new("UnreliableRemoteEvent")
 	unreliableRemote.Name = "ByteNetUnreliable"
+	unreliableRemote.Archivable = false
 	unreliableRemote.OnServerEvent:Connect(onServerEvent)
 	unreliableRemote.Parent = ReplicatedStorage
 

--- a/src/replicated/values.luau
+++ b/src/replicated/values.luau
@@ -15,6 +15,7 @@ function values.start()
 	if runContext == "server" then
 		local storage = Instance.new("Folder")
 		storage.Name = "BytenetStorage"
+		storage.Archivable = false
 		storage.Parent = ReplicatedStorage
 
 		valueFolder = storage


### PR DESCRIPTION
This PR fixes the issue addressed in #21. It sets the achievable property of instances created in Replicated Storage to false.