### PR TITLE
reversed listener execution order to prevent issues with listener removal

### DIFF
--- a/src/process/read.luau
+++ b/src/process/read.luau
@@ -41,8 +41,9 @@ local function read(incoming_buff: buffer, references: { [number]: unknown }?, p
 
 		read_cursor += value_len
 
-		for _, listener in packet.getListeners() do
-			run_listener(listener, value, player)
+		local listeners = packet.getListeners()
+		for i = #listeners, 1, -1 do
+			run_listener(listeners[i], value, player)
 		end
 	end
 end


### PR DESCRIPTION
.wait() stores index as length of listeners.
if there's multiple waiting listeners, they will cause eachother's index to be offset when removed. This will lead to loss non-temporary listeners.
by reversing execution order the possiblity of this is removed.

an example of this is below.

```luau
--shared
local bytenet = require(game.ReplicatedStorage.ByteNet)

return bytenet.defineNamespace("meow", function()
    return {
        meow = bytenet.definePacket({
            value = bytenet.string
        })
    }
end)
```
```luau
--client
local mod = require(game.ReplicatedStorage.ModuleScript)

for i = 1, 2 do
    task.spawn(function()
        local tv = mod.meow.wait()
        print(tv, i)
    end)
end
```
```luau
--server
local m = require(game.ReplicatedStorage.ModuleScript)

m.meow.sendToAll("awa")
```
```luau
--current wait implimentation
	function exported.wait()
		-- define it up here so we can use it to disconnect
		local index: number

		local runningThread = coroutine.running()
		table.insert(listeners,@native function(data, player)
			task.spawn(runningThread, data, player)

			-- Disconnects the listener
			table.remove(listeners, index)
		end)

		-- we connected, time to set the index for when we need to disconnect.
		index = #listeners

		-- the listener will resume the thread
		return coroutine.yield()
	end
```